### PR TITLE
Add brython_stdlib.js to be able to use module "random"

### DIFF
--- a/brython.html
+++ b/brython.html
@@ -7,6 +7,9 @@
     <title>Brython Snake</title>
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/brython@3.8.9/brython.min.js">
     </script>
+    <script type="text/javascript"
+        src="https://cdn.jsdelivr.net/npm/brython@3.8.9/brython_stdlib.js">
+    </script>
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
 
     <style>
@@ -79,10 +82,10 @@
 
 
     <script type="text/python">
-        
+
         from browser import document, html, window
-        from javascript import Math
-        
+        import random
+
         score = 0
         high_score = 0
 
@@ -95,7 +98,7 @@
 
         pre_pause = [0,0]
         paused = False
-   
+
         def game():
             global px, py, tc, gs, ax, ay, trail, tail, score
             px += xv
@@ -114,21 +117,21 @@
             for i in range(len(trail)):
                 ctx.fillRect(trail[i][0]*gs, trail[i][1]*gs, gs-2, gs-2)
                 if trail[i][0] == px and trail[i][1] == py:
-                    score = score if paused else 0 
+                    score = score if paused else 0
                     tail = tail if paused else 5
             trail.insert(0, [px, py])
             while len(trail) > tail:
                 trail.pop()
-        
+
             if ax == px and ay == py:
                 tail += 1
-                ax = Math.floor(Math.random()*tc)
-                ay = Math.floor(Math.random()*tc)
+                ax = int(random.random()*tc)
+                ay = int(random.random()*tc)
                 score += 1
             update_score(score)
             ctx.fillStyle = "red"
             ctx.fillRect(ax*gs, ay*gs, gs-2, gs-2)
-        
+
         def update_score(new_score):
             global high_score
             document["score"].innerHTML = "Score: " + str(new_score)
@@ -157,18 +160,18 @@
                 yv = pre_pause[1]
                 pre_pause = [*temp]
                 paused = not paused
-            
+
         def show_instructions(evt):
             window.alert("Use the arrow keys to move and press spacebar to pause the game.")
-        
+
         canvas = document["game-board"]
         ctx = canvas.getContext("2d")
         document.addEventListener("keydown", key_push)
         game_loop = window.setInterval(game, 1000/15)
         instructions_btn = document["instructions-btn"]
         instructions_btn.addEventListener("click", show_instructions)
-    
-    
+
+
 </script>
 
 </body>


### PR DESCRIPTION
Congratulations and many thanks for your post on medium.com about Brython !

I propose this PR because in this post you wrote that you couldn't use this module although it's in CPython standard distribution : it was because you didn't load the file __`brython_stdlib.js`__ in the HTML page.

As a side note, may I also report another point in the post that is not completely correct ? You write that all Javascript objects available in the page (from the JS global namespace of from third-party programs such as jQuery) with

```python
from javascript import <library>
```
but in fact it's
```python
from browser import window
jq = window.<library> # eg window.jQuery
```

The __`javascript`__ module is limited to a few built-in Javascript objects, whereas `window` is the same as in Javascript programs: a "catch-all" object that references Javascript-specific objects (`Date, String, RegExp` etc.), all the names defined by the Web API (`XMLHttpRequest, JSON, localStorage`, etc...), and those defined in these third-party programs loaded in the page (eg `jQuery`).